### PR TITLE
deprecated function add_intro_editor changed to standard_intro_elements

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -50,7 +50,7 @@ class mod_advmindmap_mod_form extends moodleform_mod {
         $mform->setDefault('editable', 1);
         
 		// add intro section
-        $this->add_intro_editor(true, get_string('advmindmapintro', 'advmindmap'));
+        $this->standard_intro_elements(get_string('advmindmapintro', 'advmindmap'));
         
         // add dummy groups settings
         $dummyoptions = array();


### PR DESCRIPTION
checked in moodle 3.1, only that method was deprecated.
